### PR TITLE
Fix all toolchains for Bazel v1.0+

### DIFF
--- a/tools/aarch64--glibc--bleeding-edge-2018.07-1/BUILD
+++ b/tools/aarch64--glibc--bleeding-edge-2018.07-1/BUILD
@@ -40,6 +40,7 @@ filegroup(
         "//tools/aarch64--glibc--bleeding-edge-2018.07-1/aarch64-linux:as",
         "//tools/aarch64--glibc--bleeding-edge-2018.07-1/aarch64-linux:gcc",
         "//tools/aarch64--glibc--bleeding-edge-2018.07-1/aarch64-linux:ld",
+        "@bootlin_aarch64_toolchain//:compiler_pieces",
     ],
 )
 

--- a/tools/armv7-eabihf--glibc--bleeding-edge-2018.07-1/BUILD
+++ b/tools/armv7-eabihf--glibc--bleeding-edge-2018.07-1/BUILD
@@ -40,6 +40,7 @@ filegroup(
         "//tools/armv7-eabihf--glibc--bleeding-edge-2018.07-1/arm-linux:as",
         "//tools/armv7-eabihf--glibc--bleeding-edge-2018.07-1/arm-linux:gcc",
         "//tools/armv7-eabihf--glibc--bleeding-edge-2018.07-1/arm-linux:ld",
+        "@bootlin_arm_toolchain//:compiler_pieces",
     ],
 )
 

--- a/tools/x86-64-core-i7--glibc--bleeding-edge-2018.07-1/BUILD
+++ b/tools/x86-64-core-i7--glibc--bleeding-edge-2018.07-1/BUILD
@@ -40,6 +40,7 @@ filegroup(
         "//tools/x86-64-core-i7--glibc--bleeding-edge-2018.07-1/x86_64-linux:as",
         "//tools/x86-64-core-i7--glibc--bleeding-edge-2018.07-1/x86_64-linux:gcc",
         "//tools/x86-64-core-i7--glibc--bleeding-edge-2018.07-1/x86_64-linux:ld",
+        "@bootlin_x86_64_toolchain//:compiler_pieces",
     ],
 )
 

--- a/tools/x86-i686--glibc--bleeding-edge-2018.07-1/BUILD
+++ b/tools/x86-i686--glibc--bleeding-edge-2018.07-1/BUILD
@@ -40,6 +40,7 @@ filegroup(
         "//tools/x86-i686--glibc--bleeding-edge-2018.07-1/i686-linux:as",
         "//tools/x86-i686--glibc--bleeding-edge-2018.07-1/i686-linux:gcc",
         "//tools/x86-i686--glibc--bleeding-edge-2018.07-1/i686-linux:ld",
+        "@bootlin_i686_toolchain//:compiler_pieces",
     ],
 )
 

--- a/tools/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0/BUILD
+++ b/tools/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0/BUILD
@@ -40,6 +40,7 @@ filegroup(
         "//tools/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0/xtensa-esp32-elf:as",
         "//tools/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0/xtensa-esp32-elf:gcc",
         "//tools/xtensa-esp32-elf-linux64-1.22.0-80-g6c4433a-5.2.0/xtensa-esp32-elf:ld",
+        "@xtensa_esp32_elf_linux64//:compiler_pieces",
     ],
 )
 


### PR DESCRIPTION
Bazel 1.0 flips [`--incompatible_use_specific_tool_files`][1]. We now need to
specify all compilation dependencies in `compiler_files`.

[1]: https://github.com/bazelbuild/bazel/issues/8531